### PR TITLE
Wrap body to follow best practice.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ RUN apt-get update && apt-get install -y \
     curl \
     libcurl4-gnutls-dev \
     libexif-dev \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd opcache iconv mcrypt pdo_pgsql pdo_mysql mbstring mysqli soap intl zip curl exif bcmath \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ \
+    --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install gd opcache iconv mcrypt pdo_pgsql \
+    pdo_mysql mbstring mysqli soap intl zip curl exif bcmath \
     && pecl install imagick \
     && docker-php-ext-enable imagick \ 
     && rm -r /var/lib/apt/lists/* \


### PR DESCRIPTION
Wrap the body at 72 characters
Git never wraps text automatically. When you write the body of a commit message, you must mind its right margin, and wrap text manually.

The recommendation is to do this at 72 characters, so that git has plenty of room to indent text while still keeping everything under 80 characters overall.

A good text editor can help here. It's easy to configure Vim, for example, to wrap text at 72 characters when you're writing a git commit. Traditionally, however, IDEs have been terrible at providing smart support for text wrapping in commit messages (although in recent versions, IntelliJ IDEA has finally gotten better about this).